### PR TITLE
ci: Add PR labeler [TEST]

### DIFF
--- a/.github/labeler_cfg.yml
+++ b/.github/labeler_cfg.yml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+BSP:
+  - changed-files:
+      - any-glob-to-any-file: hw/bsp/**
+
+CI:
+  - changed-files:
+      - any-glob-to-any-file: .github/workflows/**
+
+Dialog:
+  - changed-files:
+      - any-glob-to-any-file: ['hw/mcu/dialog/**, hw/bsp/dialog*/**']
+
+Nordic:
+  - changed-files:
+      - any-glob-to-any-file: ['hw/mcu/nordic/**', 'hw/bsp/nordic*/**']
+
+STM:
+  - changed-files:
+      - any-glob-to-any-file: ['hw/mcu/stm/**', 'hw/bsp/stm*/**']
+
+USB:
+  - changed-files:
+      - any-glob-to-any-file: hw/usb/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Pull Request Labeler"
+on:
+  - pull_request
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Assign labels based on paths
+        uses: actions/labeler@v5
+        with:
+          sync-labels: true
+          configuration-path: .github/labeler_cfg.yml
+
+      - name: Assign labels based on the PR's size
+        uses: codelytv/pr-size-labeler@v1.10.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ignore_file_deletions: true


### PR DESCRIPTION
Adds a new workflow for adding labels to Pull Requests. The labels are based on the paths of changed files and the number of altered lines.